### PR TITLE
[*] 修复了 PFolder 加载时报假问题

### DIFF
--- a/src/main/java/org/serverct/parrot/parrotx/config/PFolder.java
+++ b/src/main/java/org/serverct/parrot/parrotx/config/PFolder.java
@@ -52,7 +52,7 @@ public class PFolder extends PDataFolder {
 
     @Override
     public void saveDefault() {
-        if (!folder.mkdirs()) {
+        if (!folder.exists()) {
             plugin.lang.logError(I18n.GENERATE, getTypeName(), "自动生成失败");
         }
     }


### PR DESCRIPTION
尝试修复 PFolder 报假问题
原因:
saveDefault() 方法判断的是 !folder.mkdirs()
而saveDefault调用前面已经mkdirs了并且成功了
我认为已经mkdirs了 再mkdirs会因为文件夹已存在而无法创建
所以会报假 实际上文件夹以及里面的内容正常加载了