### PR TITLE
修初始化配置文件为null

### DIFF
--- a/src/main/java/org/serverct/parrot/parrotx/PPlugin.java
+++ b/src/main/java/org/serverct/parrot/parrotx/PPlugin.java
@@ -106,10 +106,11 @@ public abstract class PPlugin extends JavaPlugin {
             pConfig.init();
             localeKey = pConfig.getConfig().getString("Language");
             ParrotX.setDebugMode(pConfig.getConfig().getBoolean("Debug", false));
+
+            index.initConfig();
+            index.registerConfiguration(pConfig);
         }
 
-        index.initConfig();
-        index.registerConfiguration(pConfig);
 
         load();
     }


### PR DESCRIPTION
（如果我没搞错PIndex的话，这么修是正确的）
如果不给pConfig赋值，pConfig会为null，这样index initConfig就会出现空指针错误：
`[19:16:22 INFO]: PlayerTPSLimiter>> 初始化 插件 时遇到错误(java.lang.NullPointerException).
[19:16:22 INFO]: ========================= printStackTrace =========================
[19:16:22 INFO]: Exception Type ▶
[19:16:22 INFO]: java.lang.NullPointerException
[19:16:22 INFO]: No description.
[19:16:22 INFO]:
[19:16:22 INFO]: Package cn.lingyuncraft.playertpslimiter.utils ▶
[19:16:22 INFO]:   ▶ at Class PIndex, Method registerConfiguration. (PIndex.java, Line 73)
[19:16:22 INFO]:   ▶ at Class PPlugin, Method init. (PPlugin.java, Line 111)
[19:16:22 INFO]:   ▶ at Class PPlugin, Method onEnable. (PPlugin.java, Line 57)
[19:16:22 INFO]:
[19:16:22 INFO]: Package cn.lingyuncraft ▶
[19:16:22 INFO]:   ▶ at Class PlayerTPSLimiter, Method onEnable. (PlayerTPSLimiter.java, Line 13)
[19:16:22 INFO]: ========================= printStackTrace =========================`
但是我在写完上面这段信息后，又看了一下PIndex，我感觉如果不赋值pConfig也不会出现这种错误
思绪越来越乱了（
反正我没给pconfig赋值就有这问题 我不管我不管（

————————————————————————
19:49：
我发之前又看了一眼堆栈，发现问题是出在PPlugin的111行，是index.registerConfiguration(pConfig)
那pConfig为null 所以肯定会出事
所以我修的是对的 大可当上面瞎扯淡
不过initConfig方法不知道放在判断里面还是外面
就这样。